### PR TITLE
Don't introduce extra white in string value

### DIFF
--- a/src/components/simple-text.vue
+++ b/src/components/simple-text.vue
@@ -9,9 +9,7 @@
     <span
       v-else
       :class="valueClass"
-    >
-      {{ defaultFormatter(data) }}
-    </span>
+    >{{ defaultFormatter(data) }}</span>
   </div>
 </template>
 


### PR DESCRIPTION
Having extra spaces added before and after the formatted value
can make a difference when using "white-space: pre" or other similar
white space formatting CSS.

This bug was re-introduced in https://github.com/leezng/vue-json-pretty/commit/0d48ac0450fc044becd28f214c30488e537dd5cb