### PR TITLE
feature/show-line-number

### DIFF
--- a/src/assets/less/line-number.less
+++ b/src/assets/less/line-number.less
@@ -1,0 +1,7 @@
+@import "./var.less";
+
+.@{css-prefix}-line-number {
+  position: absolute;
+  left: -@selectabl-span;
+  color: #1f2d3d;
+}

--- a/src/components/brackets-right.vue
+++ b/src/components/brackets-right.vue
@@ -13,6 +13,9 @@
   import bracketsMixin from 'src/mixins/brackets-mixin'
 
   export default {
-    mixins: [bracketsMixin]
+    mixins: [bracketsMixin],
+    created () {
+      this.$emit('rightBracketLoaded')
+    }
   }
 </script>


### PR DESCRIPTION
extension and fix of:
https://github.com/leezng/vue-json-pretty/pull/48

Due to the recursive nature of the project I was able to accurately track the line number by passing an array and incrementing it as each line is added to the stack.

The hard part was getting the correct line number when items are popped off the stack before displaying closing brackets such as `}` and `]`. I handled these by grabbing the most recent line number from the `$refs` and re-incrementing and passing a new recursiveLineCount array for any continuation of closing brackets, while also incrementing the lineCount array so when opening brackets returns the count remains accurate.

Handled a few edge cases and tests. Would like to see more testing.

Note: This prop does not work with the selectable prop, will need to adjust styling.

A little jenky because of the recursive nature, but it is accurate and a starting point to go off from.