### PR TITLE
Add deepCollapseChildren prop for allowing deeply collapsed children

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ plugins: [
 | ------------------------ | ------ | --------------------------------------------------------------------------------------- | ---------------------------------------------- | -------- |
 | data                     | normal | JSON data                                                                               | JSON object                                    | -        |
 | deep                     | normal | Data depth, data larger than this depth will not be expanded                            | number                                         | Infinity |
+| deepCollapseChildren     | normal | Whether children collapsed by `deep` prop should also be collapsed                      | boolean                                         | false |
 | showLength               | normal | Whether to show the length when closed                                                  | boolean                                        | false    |
 | showLine                 | normal | Whether to show the line                                                                | boolean                                        | true     |
 | showDoubleQuotes         | normal | Whether to show doublequotes on key                                                     | boolean                                        | true     |

--- a/src/components/Tree/index.vue
+++ b/src/components/Tree/index.vue
@@ -55,6 +55,10 @@ export default {
       type: Number,
       default: Infinity,
     },
+    deepCollapseChildren: {
+      type: Boolean,
+      default: false,
+    },
     // 数据层级顶级路径
     path: {
       type: String,
@@ -129,9 +133,12 @@ export default {
       translateY: 0,
       visibleData: null,
       hiddenPaths: jsonFlatten(this.data, this.path).reduce((acc, item) => {
+        const depthComparison = this.deepCollapseChildren
+          ? item.level >= this.deep
+          : item.level === this.deep;
         if (
           (item.type === 'objectStart' || item.type === 'arrayStart') &&
-          item.level === this.deep
+          depthComparison
         ) {
           return {
             ...acc,


### PR DESCRIPTION
_There is also a PR for the `dev` branch in #131, this PR is for the `1.x` branch_

---

When a user specifies a depth to be collapsed, the intention is to make the JSON tidy so it is easy to visually parse.

Currently the `deep` prop only collapses at the specific level passed, and when a user opens that depth, all children are fully open.

I think this should collapse all children beyond the depth level, so that when the items are opened up the children are collapsed.

That said, for backwards compatibility I've implemented this as a new prop, defaulting to false, so that anyone upgrading won't see a change in behaviour.

I'm not sure on the naming of the prop, but feel like this would be beneficial and would resolve #125.