### PR TITLE
Add deepCollapseChildren prop for allowing deeply collapsed children

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ plugins: [
 | ------------------------ | ------ | --------------------------------------------------------------------------------------- | ---------------------------------------------- | -------- |
 | data                     | normal | JSON data                                                                               | JSON object                                    | -        |
 | deep                     | normal | Data depth, data larger than this depth will not be expanded                            | number                                         | Infinity |
+| deepCollapseChildren     | normal | Whether children collapsed by `deep` prop should also be collapsed                      | boolean                                         | false |
 | showLength               | normal | Whether to show the length when closed                                                  | boolean                                        | false    |
 | showLine                 | normal | Whether to show the line                                                                | boolean                                        | true     |
 | showDoubleQuotes         | normal | Whether to show doublequotes on key                                                     | boolean                                        | true     |

--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -34,6 +34,10 @@
             <option :value="4">4</option>
           </select>
         </div>
+        <div>
+          <label>deepCollapseChildren</label>
+          <input v-model="deepCollapseChildren" type="checkbox" />
+        </div>
       </div>
     </div>
     <div class="block">
@@ -41,6 +45,7 @@
       <vue-json-pretty
         :data="state.data"
         :deep="state.deep"
+        :deepCollapseChildren="deepCollapseChildren"
         :show-double-quotes="state.showDoubleQuotes"
         :show-length="state.showLength"
         :show-line="state.showLine"
@@ -96,6 +101,7 @@ export default defineComponent({
       collapsedOnClickBrackets: true,
       useCustomLinkFormatter: false,
       deep: 3,
+      deepCollapseChildren: false,
     });
 
     const customLinkFormatter = (data, key, path, defaultFormatted) => {

--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -20,6 +20,10 @@ export default defineComponent({
       type: Number,
       default: Infinity,
     },
+    deepCollapseChildren: {
+      type: Boolean,
+      default: false,
+    },
     // Data root path.
     path: {
       type: String,
@@ -57,9 +61,12 @@ export default defineComponent({
       translateY: 0,
       visibleData: null as FlatDataType | null,
       hiddenPaths: jsonFlatten(props.data, props.path).reduce((acc, item) => {
+        const depthComparison = this.deepCollapseChildren
+          ? item.level >= this.deep
+          : item.level === this.deep;
         if (
           (item.type === 'objectStart' || item.type === 'arrayStart') &&
-          item.level === props.deep
+          depthComparison
         ) {
           return {
             ...acc,


### PR DESCRIPTION
_This is implementing the same logic as in #130 but for the dev branch (Vue 3). I haven't tested this version but did test the Vue 2 version and the logic is the same._

---

When a user specifies a depth to be collapsed, the intention is to make the JSON tidy so it is easy to visually parse.

Currently the `deep` prop only collapses at the specific level passed, and when a user opens that depth, all children are fully open.

I think this should collapse all children beyond the depth level, so that when the items are opened up the children are collapsed.

That said, for backwards compatibility I've implemented this as a new prop, defaulting to false, so that anyone upgrading won't see a change in behaviour.

I'm not sure on the naming of the prop, but feel like this would be beneficial and would resolve #125.