### PR TITLE
Add `deepCollapseChildren` to basic demo

### DIFF
--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -44,6 +44,10 @@
             </option>
           </select>
         </div>
+        <div>
+          <label>deepCollapseChildren</label>
+          <input v-model="deepCollapseChildren" type="checkbox" />
+        </div>
       </div>
     </div>
     <div class="block">
@@ -51,6 +55,7 @@
       <vue-json-pretty
         :data="data"
         :deep="deep"
+        :deepCollapseChildren="deepCollapseChildren"
         :show-double-quotes="showDoubleQuotes"
         :show-length="showLength"
         :show-line="showLine"
@@ -107,6 +112,7 @@ export default {
       collapsedOnClickBrackets: true,
       useCustomLinkFormatter: false,
       deep: 3,
+      deepCollapseChildren: false,
     };
   },
   watch: {


### PR DESCRIPTION
This is a new option provided for collapsing children inside those collapsed by default, so is exposed here.

I've not tested this out so worth doing a quick test but should work.