### PR TITLE
Add Word Break Styling to VTreeNode

### DIFF
--- a/src/components/TreeNode/styles.less
+++ b/src/components/TreeNode/styles.less
@@ -45,3 +45,7 @@
 .@{css-prefix}-value__string {
   .gen-value-style(@color-string);
 }
+
+.@{css-prefix}-key {
+  word-break: normal;
+}


### PR DESCRIPTION
For very large strings stored in JSON a user is easily tempted to apply the styling:

`style="word-break: break-all;"`

However, this can affect the JSON key in `vue-json-pretty` to cause it to also word-break and appear malformed. Adding this line of styling will keep that from happening. 

It is easy to add this from the project itself, but thought that it would be useful to be part of the source code, as I am sure this is a common practice for displaying json.

