### PR TITLE
fix/xss-issue

### DIFF
--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -109,11 +109,9 @@ export default defineComponent({
       return text;
     };
 
-    const customFormatter = (data: string) => {
-      return props.customValueFormatter
-        ? props.customValueFormatter(data, props.node.key, props.node.path, defaultFormatter(data))
-        : defaultFormatter(data);
-    };
+    const customFormatter = props.customValueFormatter
+      ? (data: string) => props.customValueFormatter(data, props.node.key, props.node.path, defaultFormatter(data))
+      : null;
 
     const onBracketsClickHandler = () => {
       if (props.collapsedOnClickBrackets) {


### PR DESCRIPTION
Fixes #150 
`customFormatter` is always defined even though `customValueFormatter` is not passed, this causes default usage of XSS-vulnerable [v-html](https://v2.vuejs.org/v2/api/?redirect=true#v-html)
temporary published to npm with this fix https://www.npmjs.com/package/@souljorje/vue-json-pretty