### PR TITLE
Escape strings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ plugins: [
 | showLength               | normal | Whether to show the length when closed                                                  | boolean                                        | false    |
 | showLine                 | normal | Whether to show the line                                                                | boolean                                        | true     |
 | showDoubleQuotes         | normal | Whether to show doublequotes on key                                                     | boolean                                        | true     |
+| escapeStrings            | normal | Whether to escape special characters in strings                                         | boolean                                        | true     |
 | virtual                  | normal | Whether to use virtual scrolling, usually used for big data                             | boolean                                        | false    |
 | itemHeight               | normal | The height of each item when using virtual scrolling                                    | number                                         | auto     |
 | v-model                  | higher | Defines value when the tree can be selected                                             | string, array                                  | -        |

--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -20,6 +20,11 @@ export const treeNodePropsPass = {
     type: Boolean,
     default: true,
   },
+  // Whether the string values are escaped
+  escapeStrings: {
+    type: Boolean,
+    default: true,
+  },
   // Custom formatter for values.
   customValueFormatter: Function as PropType<
     (data: string, key: NodeDataType['key'], path: string, defaultFormatResult: string) => unknown
@@ -105,7 +110,7 @@ export default defineComponent({
 
     const defaultFormatter = (data: string) => {
       let text = data + '';
-      if (dataType.value === 'string') text = `"${text}"`;
+      if (dataType.value === 'string') text = props.escapeStrings ? JSON.stringify(text) : `"${text}"`;
       return text;
     };
 


### PR DESCRIPTION
`vue-json-pretty` may receive arbitrary string data, including string data containing newlines, null bytes, quotes, and other escaped characters. Escape these characters by default to make copying/exporting as JSON easier and more consistent.