### PR TITLE
feat: add darkmode to site and add theme prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,31 +106,32 @@ plugins: [
 
 ## Props
 
-| Property                  | Description                                                                     | Type                              | Default |
-|---------------------------|---------------------------------------------------------------------------------|-----------------------------------| ------- |
-| data(v-model)             | JSON data, support v-model when use editable                                    | JSON object                       | -       |
-| collapsedNodeLength       | Objects or arrays which length is greater than this threshold will be collapsed | number                            | -       |
-| deep                      | Paths greater than this depth will be collapsed                                 | number                            | -       |
-| showLength                | Show the length when collapsed                                                  | boolean                           | false   |
-| showLine                  | Show the line                                                                   | boolean                           | true    |
-| showLineNumber            | Show the line number                                                            | boolean                           | false   |
-| showIcon                  | Show the icon                                                                   | boolean                           | false   |
-| showDoubleQuotes          | Show doublequotes on key                                                        | boolean                           | true    |
-| virtual                   | Use virtual scroll                                                              | boolean                           | false   |
-| height                    | The height of list when using virtual                                           | number                            | 400     |
-| itemHeight                | The height of node when using virtual                                           | number                            | 20      |
-| selectedValue(v-model)    | Selected data path                                                              | string, array                     | -       |
-| rootPath                  | Root data path                                                                  | string                            | `root`  |
-| nodeSelectable            | Defines whether a node supports selection                                       | (node) => boolean                 | -       |
-| selectableType            | Support path select, default none                                               | `multiple` \| `single`            | -       |
-| showSelectController      | Show the select controller                                                      | boolean                           | false   |
-| selectOnClickNode         | Trigger select when click node                                                  | boolean                           | true    |
-| highlightSelectedNode     | Support highlighting selected nodes                                             | boolean                           | true    |
-| collapsedOnClickBrackets  | Support click brackets to collapse                                              | boolean                           | true    |
-| renderNodeKey             | render node key, or use slot #renderNodeKey                                     | ({ node, defaultKey }) => vNode   | -       |
-| renderNodeValue           | render node value, or use slot #renderNodeValue                                 | ({ node, defaultValue }) => vNode | -       |
-| editable                  | Support editable                                                                | boolean                           | false   |
-| editableTrigger           | Trigger                                                                         | `click` \| `dblclick`             | `click` |
+| Property                 | Description                                                                          | Type                              | Default |
+| ------------------------ | ------------------------------------------------------------------------------------ | --------------------------------- | ------- |
+| data(v-model)            | JSON data, support v-model when use editable                                         | JSON object                       | -       |
+| collapsedNodeLength      | Objects or arrays which length is greater than this threshold will be collapsed      | number                            | -       |
+| deep                     | Paths greater than this depth will be collapsed                                      | number                            | -       |
+| showLength               | Show the length when collapsed                                                       | boolean                           | false   |
+| showLine                 | Show the line                                                                        | boolean                           | true    |
+| showLineNumber           | Show the line number                                                                 | boolean                           | false   |
+| showIcon                 | Show the icon                                                                        | boolean                           | false   |
+| showDoubleQuotes         | Show doublequotes on key                                                             | boolean                           | true    |
+| virtual                  | Use virtual scroll                                                                   | boolean                           | false   |
+| height                   | The height of list when using virtual                                                | number                            | 400     |
+| itemHeight               | The height of node when using virtual                                                | number                            | 20      |
+| selectedValue(v-model)   | Selected data path                                                                   | string, array                     | -       |
+| rootPath                 | Root data path                                                                       | string                            | `root`  |
+| nodeSelectable           | Defines whether a node supports selection                                            | (node) => boolean                 | -       |
+| selectableType           | Support path select, default none                                                    | `multiple` \| `single`            | -       |
+| showSelectController     | Show the select controller                                                           | boolean                           | false   |
+| selectOnClickNode        | Trigger select when click node                                                       | boolean                           | true    |
+| highlightSelectedNode    | Support highlighting selected nodes                                                  | boolean                           | true    |
+| collapsedOnClickBrackets | Support click brackets to collapse                                                   | boolean                           | true    |
+| renderNodeKey            | render node key, or use slot #renderNodeKey                                          | ({ node, defaultKey }) => vNode   | -       |
+| renderNodeValue          | render node value, or use slot #renderNodeValue                                      | ({ node, defaultValue }) => vNode | -       |
+| editable                 | Support editable                                                                     | boolean                           | false   |
+| editableTrigger          | Trigger                                                                              | `click` \| `dblclick`             | `click` |
+| darkHighlightMode        | Enables a dark theme for hover highlights, improving visibility on dark backgrounds. | boolean                           | false   |
 
 ## Events
 
@@ -145,7 +146,7 @@ plugins: [
 
 | Slot Name       | Description       | Parameters             |
 | --------------- | ----------------- | ---------------------- |
-| renderNodeKey   | render node key   | { node, defaultKey }        |
+| renderNodeKey   | render node key   | { node, defaultKey }   |
 | renderNodeValue | render node value | { node, defaultValue } |
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -106,32 +106,32 @@ plugins: [
 
 ## Props
 
-| Property                 | Description                                                                          | Type                              | Default |
-| ------------------------ | ------------------------------------------------------------------------------------ | --------------------------------- | ------- |
-| data(v-model)            | JSON data, support v-model when use editable                                         | JSON object                       | -       |
-| collapsedNodeLength      | Objects or arrays which length is greater than this threshold will be collapsed      | number                            | -       |
-| deep                     | Paths greater than this depth will be collapsed                                      | number                            | -       |
-| showLength               | Show the length when collapsed                                                       | boolean                           | false   |
-| showLine                 | Show the line                                                                        | boolean                           | true    |
-| showLineNumber           | Show the line number                                                                 | boolean                           | false   |
-| showIcon                 | Show the icon                                                                        | boolean                           | false   |
-| showDoubleQuotes         | Show doublequotes on key                                                             | boolean                           | true    |
-| virtual                  | Use virtual scroll                                                                   | boolean                           | false   |
-| height                   | The height of list when using virtual                                                | number                            | 400     |
-| itemHeight               | The height of node when using virtual                                                | number                            | 20      |
-| selectedValue(v-model)   | Selected data path                                                                   | string, array                     | -       |
-| rootPath                 | Root data path                                                                       | string                            | `root`  |
-| nodeSelectable           | Defines whether a node supports selection                                            | (node) => boolean                 | -       |
-| selectableType           | Support path select, default none                                                    | `multiple` \| `single`            | -       |
-| showSelectController     | Show the select controller                                                           | boolean                           | false   |
-| selectOnClickNode        | Trigger select when click node                                                       | boolean                           | true    |
-| highlightSelectedNode    | Support highlighting selected nodes                                                  | boolean                           | true    |
-| collapsedOnClickBrackets | Support click brackets to collapse                                                   | boolean                           | true    |
-| renderNodeKey            | render node key, or use slot #renderNodeKey                                          | ({ node, defaultKey }) => vNode   | -       |
-| renderNodeValue          | render node value, or use slot #renderNodeValue                                      | ({ node, defaultValue }) => vNode | -       |
-| editable                 | Support editable                                                                     | boolean                           | false   |
-| editableTrigger          | Trigger                                                                              | `click` \| `dblclick`             | `click` |
-| darkHighlightMode        | Enables a dark theme for hover highlights, improving visibility on dark backgrounds. | boolean                           | false   |
+| Property                 | Description                                                                                                             | Type                              | Default |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------- |
+| data(v-model)            | JSON data, support v-model when use editable                                                                            | JSON object                       | -       |
+| collapsedNodeLength      | Objects or arrays which length is greater than this threshold will be collapsed                                         | number                            | -       |
+| deep                     | Paths greater than this depth will be collapsed                                                                         | number                            | -       |
+| showLength               | Show the length when collapsed                                                                                          | boolean                           | false   |
+| showLine                 | Show the line                                                                                                           | boolean                           | true    |
+| showLineNumber           | Show the line number                                                                                                    | boolean                           | false   |
+| showIcon                 | Show the icon                                                                                                           | boolean                           | false   |
+| showDoubleQuotes         | Show doublequotes on key                                                                                                | boolean                           | true    |
+| virtual                  | Use virtual scroll                                                                                                      | boolean                           | false   |
+| height                   | The height of list when using virtual                                                                                   | number                            | 400     |
+| itemHeight               | The height of node when using virtual                                                                                   | number                            | 20      |
+| selectedValue(v-model)   | Selected data path                                                                                                      | string, array                     | -       |
+| rootPath                 | Root data path                                                                                                          | string                            | `root`  |
+| nodeSelectable           | Defines whether a node supports selection                                                                               | (node) => boolean                 | -       |
+| selectableType           | Support path select, default none                                                                                       | `multiple` \| `single`            | -       |
+| showSelectController     | Show the select controller                                                                                              | boolean                           | false   |
+| selectOnClickNode        | Trigger select when click node                                                                                          | boolean                           | true    |
+| highlightSelectedNode    | Support highlighting selected nodes                                                                                     | boolean                           | true    |
+| collapsedOnClickBrackets | Support click brackets to collapse                                                                                      | boolean                           | true    |
+| renderNodeKey            | render node key, or use slot #renderNodeKey                                                                             | ({ node, defaultKey }) => vNode   | -       |
+| renderNodeValue          | render node value, or use slot #renderNodeValue                                                                         | ({ node, defaultValue }) => vNode | -       |
+| editable                 | Support editable                                                                                                        | boolean                           | false   |
+| editableTrigger          | Trigger                                                                                                                 | `click` \| `dblclick`             | `click` |
+| theme                    | Sets the theme of the component. Options are 'light' or 'dark', with dark mode enhancing visibility on dark backgrounds | `'light' \| 'dark'`               | `light` |
 
 ## Events
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -5,6 +5,7 @@ import SelectControl from './SelectControl.vue';
 import Editable from './Editable.vue';
 // import Tsx from './Tsx';
 import './styles.less';
+import { MoonIcon, SunIcon } from './Icons';
 
 const list = [
   {
@@ -33,46 +34,6 @@ const list = [
   //   component: Tsx,
   // },
 ];
-
-const SunIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="12" cy="12" r="5"></circle>
-    <line x1="12" y1="1" x2="12" y2="3"></line>
-    <line x1="12" y1="21" x2="12" y2="23"></line>
-    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-    <line x1="1" y1="12" x2="3" y2="12"></line>
-    <line x1="21" y1="12" x2="23" y2="12"></line>
-    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-  </svg>
-);
-
-const MoonIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M21 12.79A9 9 0 0112.21 3C11.66 3 11.11 3.05 10.58 3.15A9 9 0 1021 12.79z"></path>
-  </svg>
-);
 
 export default defineComponent({
   setup() {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -75,11 +75,12 @@ export default defineComponent({
       state,
       onActiveChange,
       toggleDarkMode,
+      globalDarkModeState,
     };
   },
 
   render() {
-    const { state, onActiveChange, toggleDarkMode } = this;
+    const { state, onActiveChange, toggleDarkMode, globalDarkModeState } = this;
 
     return (
       <div class={`example ${state.isDarkMode ? 'dark-mode' : ''}`}>
@@ -103,7 +104,7 @@ export default defineComponent({
               ))}
             </div>
             <div class="dark-mode-toggle" onClick={toggleDarkMode}>
-              {state.isDarkMode ? <SunIcon /> : <MoonIcon />}
+              {globalDarkModeState.isDarkMode ? <SunIcon /> : <MoonIcon />}
             </div>
           </div>
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, reactive, provide, onMounted } from 'vue';
+import { defineComponent, reactive, provide, onMounted, watch } from 'vue';
 import Basic from './Basic.vue';
 import VirtualList from './VirtualList.vue';
 import SelectControl from './SelectControl.vue';
@@ -79,10 +79,13 @@ export default defineComponent({
     const state = reactive({
       activeKey: list[0].key,
       opened: [list[0].key],
+    });
+
+    const globalDarkModeState = reactive({
       isDarkMode: window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches,
     });
 
-    provide('darkModeState', state);
+    provide('darkModeState', globalDarkModeState);
 
     const onActiveChange = (key: string) => {
       state.activeKey = key;
@@ -91,23 +94,31 @@ export default defineComponent({
       }
     };
 
+    const toggleDarkMode = () => {
+      globalDarkModeState.isDarkMode = !globalDarkModeState.isDarkMode;
+    };
+
     onMounted(() => {
-      document.body.classList.toggle('dark-mode', state.isDarkMode);
+      document.body.classList.toggle('dark-mode', globalDarkModeState.isDarkMode);
     });
+
+    watch(
+      () => globalDarkModeState.isDarkMode,
+      newVal => {
+        document.body.classList.toggle('dark-mode', newVal);
+      },
+      { immediate: true },
+    );
 
     return {
       state,
       onActiveChange,
+      toggleDarkMode,
     };
   },
 
   render() {
-    const { state, onActiveChange } = this;
-
-    const toggleDarkMode = () => {
-      state.isDarkMode = !state.isDarkMode;
-      document.body.classList.toggle('dark-mode', state.isDarkMode);
-    };
+    const { state, onActiveChange, toggleDarkMode } = this;
 
     return (
       <div class={`example ${state.isDarkMode ? 'dark-mode' : ''}`}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, reactive } from 'vue';
+import { defineComponent, reactive, provide, onMounted } from 'vue';
 import Basic from './Basic.vue';
 import VirtualList from './VirtualList.vue';
 import SelectControl from './SelectControl.vue';
@@ -34,12 +34,55 @@ const list = [
   // },
 ];
 
+const SunIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 12.79A9 9 0 0112.21 3C11.66 3 11.11 3.05 10.58 3.15A9 9 0 1021 12.79z"></path>
+  </svg>
+);
+
 export default defineComponent({
   setup() {
     const state = reactive({
       activeKey: list[0].key,
       opened: [list[0].key],
+      isDarkMode: window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches,
     });
+
+    provide('darkModeState', state);
 
     const onActiveChange = (key: string) => {
       state.activeKey = key;
@@ -47,6 +90,10 @@ export default defineComponent({
         state.opened.push(key);
       }
     };
+
+    onMounted(() => {
+      document.body.classList.toggle('dark-mode', state.isDarkMode);
+    });
 
     return {
       state,
@@ -57,8 +104,13 @@ export default defineComponent({
   render() {
     const { state, onActiveChange } = this;
 
+    const toggleDarkMode = () => {
+      state.isDarkMode = !state.isDarkMode;
+      document.body.classList.toggle('dark-mode', state.isDarkMode);
+    };
+
     return (
-      <div class="example">
+      <div class={`example ${state.isDarkMode ? 'dark-mode' : ''}`}>
         <h1>Vue Json Pretty</h1>
         <p>
           Welcome to the demo space of Vue Json Pretty, here we provide the following different
@@ -67,15 +119,20 @@ export default defineComponent({
 
         <div class="tabs">
           <div class="tabs-header">
-            {list.map(({ title, key }) => (
-              <div
-                key={key}
-                class={`tabs-header-item ${key === state.activeKey ? 'is-active' : ''}`}
-                onClick={() => onActiveChange(key)}
-              >
-                {title}
-              </div>
-            ))}
+            <div class="tabs-items-container">
+              {list.map(({ title, key }) => (
+                <div
+                  key={key}
+                  class={`tabs-header-item ${key === state.activeKey ? 'is-active' : ''}`}
+                  onClick={() => onActiveChange(key)}
+                >
+                  {title}
+                </div>
+              ))}
+            </div>
+            <div class="dark-mode-toggle" onClick={toggleDarkMode}>
+              {state.isDarkMode ? <SunIcon /> : <MoonIcon />}
+            </div>
           </div>
 
           <div class="tabs-content">

--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
+      <textarea :class="{ 'dark-textarea': globalDarkModeState }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -153,7 +153,7 @@ export default defineComponent({
       showKeyValueSpace: true,
     });
 
-    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+    const { localDarkMode, toggleLocalDarkMode, globalDarkModeState } = useDarkMode();
 
     const pathCollapsible = node => {
       return node.key === 'members';
@@ -175,6 +175,7 @@ export default defineComponent({
       pathCollapsible,
       localDarkMode,
       toggleLocalDarkMode,
+      globalDarkModeState,
     };
   },
 });

--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -46,6 +46,10 @@
           <label>setPathCollapsible</label>
           <input v-model="state.setPathCollapsible" type="checkbox" />
         </div>
+        <div>
+          <label>darkMode</label>
+          <input v-model="state.darkMode" type="checkbox" />
+        </div>
       </div>
 
       <h3>Slots:</h3>
@@ -63,6 +67,7 @@
     <div class="block">
       <h3>vue-json-pretty:</h3>
       <vue-json-pretty
+        :darkMode="state.darkMode"
         :data="state.data"
         :deep="state.deep"
         :path-collapsible="state.setPathCollapsible ? pathCollapsible : undefined"

--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea v-model="state.val" />
+      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -47,8 +47,8 @@
           <input v-model="state.setPathCollapsible" type="checkbox" />
         </div>
         <div>
-          <label>darkMode</label>
-          <input v-model="state.darkMode" type="checkbox" />
+          <label>darkHighlightMode</label>
+          <input v-model="localDarkMode" type="checkbox" />
         </div>
       </div>
 
@@ -67,7 +67,7 @@
     <div class="block">
       <h3>vue-json-pretty:</h3>
       <vue-json-pretty
-        :darkMode="state.darkMode"
+        :darkHighlightMode="localDarkMode"
         :data="state.data"
         :deep="state.deep"
         :path-collapsible="state.setPathCollapsible ? pathCollapsible : undefined"
@@ -100,6 +100,7 @@
 
 <script>
 import { defineComponent, reactive, watch } from 'vue';
+import { useDarkMode } from './useDarkMode';
 import VueJsonPretty from 'src';
 
 const defaultData = {
@@ -152,6 +153,8 @@ export default defineComponent({
       showKeyValueSpace: true,
     });
 
+    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+
     const pathCollapsible = node => {
       return node.key === 'members';
     };
@@ -170,6 +173,8 @@ export default defineComponent({
     return {
       state,
       pathCollapsible,
+      localDarkMode,
+      toggleLocalDarkMode,
     };
   },
 });

--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -47,8 +47,11 @@
           <input v-model="state.setPathCollapsible" type="checkbox" />
         </div>
         <div>
-          <label>darkHighlightMode</label>
-          <input v-model="localDarkMode" type="checkbox" />
+          <label>theme</label>
+          <select v-model="localDarkMode">
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
         </div>
       </div>
 
@@ -67,7 +70,7 @@
     <div class="block">
       <h3>vue-json-pretty:</h3>
       <vue-json-pretty
-        :darkHighlightMode="localDarkMode"
+        :theme="localDarkMode"
         :data="state.data"
         :deep="state.deep"
         :path-collapsible="state.setPathCollapsible ? pathCollapsible : undefined"

--- a/example/Editable.vue
+++ b/example/Editable.vue
@@ -34,11 +34,16 @@
           </select>
         </div>
       </div>
+      <div>
+        <label>darkMode</label>
+        <input v-model="state.darkMode" type="checkbox" />
+      </div>
     </div>
     <div class="block">
       <h3>vue-json-pretty:</h3>
       <vue-json-pretty
         v-model:data="state.data"
+        :darkMode="state.darkMode"
         :deep="state.deep"
         :show-double-quotes="true"
         :show-line="state.showLine"

--- a/example/Editable.vue
+++ b/example/Editable.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
+      <textarea :class="{ 'dark-textarea': globalDarkModeState }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -104,7 +104,7 @@ export default defineComponent({
       deep: 3,
     });
 
-    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+    const { localDarkMode, toggleLocalDarkMode, globalDarkModeState } = useDarkMode();
 
     watch(
       () => state.val,
@@ -132,6 +132,7 @@ export default defineComponent({
       state,
       localDarkMode,
       toggleLocalDarkMode,
+      globalDarkModeState,
     };
   },
 });

--- a/example/Editable.vue
+++ b/example/Editable.vue
@@ -35,15 +35,18 @@
         </div>
       </div>
       <div>
-        <label>darkHighlightMode</label>
-        <input v-model="localDarkMode" type="checkbox" />
+        <label>theme</label>
+        <select v-model="localDarkMode">
+          <option value="light">light</option>
+          <option value="dark">dark</option>
+        </select>
       </div>
     </div>
     <div class="block">
       <h3>vue-json-pretty:</h3>
       <vue-json-pretty
         v-model:data="state.data"
-        :darkHighlightMode="localDarkMode"
+        :theme="localDarkMode"
         :deep="state.deep"
         :show-double-quotes="true"
         :show-line="state.showLine"

--- a/example/Editable.vue
+++ b/example/Editable.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea v-model="state.val" />
+      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -35,15 +35,15 @@
         </div>
       </div>
       <div>
-        <label>darkMode</label>
-        <input v-model="state.darkMode" type="checkbox" />
+        <label>darkHighlightMode</label>
+        <input v-model="localDarkMode" type="checkbox" />
       </div>
     </div>
     <div class="block">
       <h3>vue-json-pretty:</h3>
       <vue-json-pretty
         v-model:data="state.data"
-        :darkMode="state.darkMode"
+        :darkHighlightMode="localDarkMode"
         :deep="state.deep"
         :show-double-quotes="true"
         :show-line="state.showLine"
@@ -58,6 +58,7 @@
 <script>
 import { defineComponent, reactive, watch } from 'vue';
 import VueJsonPretty from 'src';
+import { useDarkMode } from './useDarkMode';
 
 const defaultData = {
   status: 200,
@@ -103,6 +104,8 @@ export default defineComponent({
       deep: 3,
     });
 
+    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+
     watch(
       () => state.val,
       newVal => {
@@ -127,7 +130,10 @@ export default defineComponent({
 
     return {
       state,
+      localDarkMode,
+      toggleLocalDarkMode,
     };
   },
 });
 </script>
+./useDarkMode

--- a/example/Icons.tsx
+++ b/example/Icons.tsx
@@ -1,0 +1,39 @@
+export const SunIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+);
+
+export const MoonIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 12.79A9 9 0 0112.21 3C11.66 3 11.11 3.05 10.58 3.15A9 9 0 1021 12.79z"></path>
+  </svg>
+);

--- a/example/SelectControl.vue
+++ b/example/SelectControl.vue
@@ -58,8 +58,11 @@
           </select>
         </div>
         <div>
-          <label>darkHighlightMode</label>
-          <input v-model="localDarkMode" type="checkbox" />
+          <label>theme</label>
+          <select v-model="localDarkMode">
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
         </div>
       </div>
       <h3>v-model:selectedValue:</h3>
@@ -72,7 +75,7 @@
       <vue-json-pretty
         v-if="state.renderOK"
         v-model:selectedValue="state.selectedValue"
-        :darkHighlightMode="localDarkMode"
+        :theme="localDarkMode"
         :data="state.data"
         :root-path="state.rootPath"
         :deep="state.deep"

--- a/example/SelectControl.vue
+++ b/example/SelectControl.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
+      <textarea :class="{ 'dark-textarea': globalDarkModeState }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -154,7 +154,7 @@ export default defineComponent({
       showIcon: false,
     });
 
-    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+    const { localDarkMode, toggleLocalDarkMode, globalDarkModeState } = useDarkMode();
 
     const handleNodeClick = node => {
       state.node = node;
@@ -196,6 +196,7 @@ export default defineComponent({
       handleAll,
       localDarkMode,
       toggleLocalDarkMode,
+      globalDarkModeState,
     };
   },
 });

--- a/example/SelectControl.vue
+++ b/example/SelectControl.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea v-model="state.val" />
+      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -58,8 +58,8 @@
           </select>
         </div>
         <div>
-          <label>darkMode</label>
-          <input v-model="state.darkMode" type="checkbox" />
+          <label>darkHighlightMode</label>
+          <input v-model="localDarkMode" type="checkbox" />
         </div>
       </div>
       <h3>v-model:selectedValue:</h3>
@@ -72,7 +72,7 @@
       <vue-json-pretty
         v-if="state.renderOK"
         v-model:selectedValue="state.selectedValue"
-        :darkMode="state.darkMode"
+        :darkHighlightMode="localDarkMode"
         :data="state.data"
         :root-path="state.rootPath"
         :deep="state.deep"
@@ -99,6 +99,7 @@
 <script>
 import { defineComponent, reactive, watch, nextTick } from 'vue';
 import VueJsonPretty from 'src';
+import { useDarkMode } from './useDarkMode';
 
 const defaultData = {
   status: 200,
@@ -153,6 +154,8 @@ export default defineComponent({
       showIcon: false,
     });
 
+    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+
     const handleNodeClick = node => {
       state.node = node;
     };
@@ -191,6 +194,8 @@ export default defineComponent({
       state,
       handleNodeClick,
       handleAll,
+      localDarkMode,
+      toggleLocalDarkMode,
     };
   },
 });

--- a/example/SelectControl.vue
+++ b/example/SelectControl.vue
@@ -57,6 +57,10 @@
             <option :value="4">4</option>
           </select>
         </div>
+        <div>
+          <label>darkMode</label>
+          <input v-model="state.darkMode" type="checkbox" />
+        </div>
       </div>
       <h3>v-model:selectedValue:</h3>
       <div>{{ state.selectedValue }}</div>
@@ -68,6 +72,7 @@
       <vue-json-pretty
         v-if="state.renderOK"
         v-model:selectedValue="state.selectedValue"
+        :darkMode="state.darkMode"
         :data="state.data"
         :root-path="state.rootPath"
         :deep="state.deep"

--- a/example/VirtualList.vue
+++ b/example/VirtualList.vue
@@ -35,14 +35,17 @@
         </div>
       </div>
       <div>
-        <label>darkHighlightMode</label>
-        <input v-model="localDarkMode" type="checkbox" />
+        <label>theme</label>
+        <select v-model="localDarkMode">
+          <option value="light">light</option>
+          <option value="dark">dark</option>
+        </select>
       </div>
     </div>
     <div class="block">
       <h3>vue-json-pretty(10000+ items):</h3>
       <vue-json-pretty
-        :darkHighlightMode="localDarkMode"
+        :theme="localDarkMode"
         :collapsed-node-length="state.collapsedNodeLength"
         :virtual="true"
         :item-height="+state.itemHeight"

--- a/example/VirtualList.vue
+++ b/example/VirtualList.vue
@@ -34,10 +34,15 @@
           </select>
         </div>
       </div>
+      <div>
+        <label>darkMode</label>
+        <input v-model="state.darkMode" type="checkbox" />
+      </div>
     </div>
     <div class="block">
       <h3>vue-json-pretty(10000+ items):</h3>
       <vue-json-pretty
+        :darkMode="state.darkMode"
         :collapsed-node-length="state.collapsedNodeLength"
         :virtual="true"
         :item-height="+state.itemHeight"

--- a/example/VirtualList.vue
+++ b/example/VirtualList.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
+      <textarea :class="{ 'dark-textarea': globalDarkModeState }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -92,7 +92,7 @@ export default defineComponent({
       itemHeight: 20,
     });
 
-    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+    const { localDarkMode, toggleLocalDarkMode, globalDarkModeState } = useDarkMode();
 
     watch(
       () => state.val,
@@ -109,6 +109,7 @@ export default defineComponent({
       state,
       localDarkMode,
       toggleLocalDarkMode,
+      globalDarkModeState,
     };
   },
 });

--- a/example/VirtualList.vue
+++ b/example/VirtualList.vue
@@ -2,7 +2,7 @@
   <div class="example-box">
     <div class="block">
       <h3>JSON:</h3>
-      <textarea v-model="state.val" />
+      <textarea :class="{ 'dark-textarea': localDarkMode }" v-model="state.val"></textarea>
 
       <h3>Options:</h3>
       <div class="options">
@@ -35,14 +35,14 @@
         </div>
       </div>
       <div>
-        <label>darkMode</label>
-        <input v-model="state.darkMode" type="checkbox" />
+        <label>darkHighlightMode</label>
+        <input v-model="localDarkMode" type="checkbox" />
       </div>
     </div>
     <div class="block">
       <h3>vue-json-pretty(10000+ items):</h3>
       <vue-json-pretty
-        :darkMode="state.darkMode"
+        :darkHighlightMode="localDarkMode"
         :collapsed-node-length="state.collapsedNodeLength"
         :virtual="true"
         :item-height="+state.itemHeight"
@@ -58,6 +58,7 @@
 <script>
 import { defineComponent, reactive, watch } from 'vue';
 import VueJsonPretty from 'src';
+import { useDarkMode } from './useDarkMode';
 
 const defaultData = {
   status: 200,
@@ -91,6 +92,8 @@ export default defineComponent({
       itemHeight: 20,
     });
 
+    const { localDarkMode, toggleLocalDarkMode } = useDarkMode();
+
     watch(
       () => state.val,
       newVal => {
@@ -104,6 +107,8 @@ export default defineComponent({
 
     return {
       state,
+      localDarkMode,
+      toggleLocalDarkMode,
     };
   },
 });

--- a/example/styles.less
+++ b/example/styles.less
@@ -121,3 +121,9 @@ body {
     text-overflow: ellipsis;
   }
 }
+
+.dark-textarea {
+  background-color: #333;
+  color: #fff;
+  border-color: #444;
+}

--- a/example/styles.less
+++ b/example/styles.less
@@ -1,4 +1,7 @@
 @primary-color: #1890ff;
+@dark-background-color: darken(#333, 5%);
+@dark-text-color: #fff;
+@dark-border-color: #555;
 
 * {
   box-sizing: border-box;
@@ -7,37 +10,59 @@
 html,
 body {
   margin: 0;
+  transition: background-color 0.3s, color 0.3s;
 }
 
 body {
   font-size: 14px;
   background-color: #f9f9f9;
+
+  &.dark-mode {
+    background-color: @dark-background-color;
+    color: @dark-text-color;
+  }
 }
 
 .tabs-header {
   display: flex;
+  justify-content: space-between;
   margin-bottom: 20px;
   border-bottom: 1px solid #ccc;
 }
 
-.tabs-header-item {
-  position: relative;
-  margin-right: 20px;
-  padding: 8px 0;
-  cursor: pointer;
-  transition: color 0.3s;
+.tabs-items-container {
+  display: flex;
 
-  &:hover,
-  &.is-active {
-    color: @primary-color;
+  .tabs-header-item {
+    position: relative;
+    margin-right: 20px;
+    padding: 8px 0;
+    cursor: pointer;
+    transition: color 0.3s;
 
-    &:after {
-      border-bottom: 2px solid @primary-color;
-      content: '';
-      width: 100%;
-      position: absolute;
-      left: 0;
-      bottom: -1px;
+    &:hover,
+    &.is-active {
+      color: @primary-color;
+
+      &:after {
+        border-bottom: 2px solid @primary-color;
+        content: '';
+        width: 100%;
+        position: absolute;
+        left: 0;
+        bottom: -1px;
+      }
+    }
+    body.dark-mode & {
+      color: @dark-text-color;
+      &:hover,
+      &.is-active {
+        color: lighten(@primary-color, 20%);
+
+        &:after {
+          border-bottom: 2px solid lighten(@primary-color, 20%);
+        }
+      }
     }
   }
 }

--- a/example/useDarkMode.ts
+++ b/example/useDarkMode.ts
@@ -1,0 +1,19 @@
+import { inject, ref, watch } from 'vue';
+
+export function useDarkMode() {
+  const darkModeState = inject('darkModeState');
+  const localDarkMode = ref(darkModeState.isDarkMode);
+
+  watch(
+    () => darkModeState.isDarkMode,
+    newVal => {
+      localDarkMode.value = newVal;
+    },
+  );
+
+  const toggleLocalDarkMode = () => {
+    darkModeState.isDarkMode = !darkModeState.isDarkMode;
+  };
+
+  return { localDarkMode, toggleLocalDarkMode };
+}

--- a/example/useDarkMode.ts
+++ b/example/useDarkMode.ts
@@ -3,18 +3,19 @@ import { inject, ref, watch } from 'vue';
 export function useDarkMode() {
   const darkModeState = inject('darkModeState');
   const globalDarkModeState = ref(darkModeState.isDarkMode);
-  const localDarkMode = ref(darkModeState.isDarkMode);
+  const localDarkMode = ref(darkModeState.isDarkMode ? 'dark' : 'light');
 
   watch(
     () => darkModeState.isDarkMode,
     newVal => {
-      localDarkMode.value = newVal;
+      localDarkMode.value = newVal ? 'dark' : 'light';
       globalDarkModeState.value = newVal;
     },
   );
 
   const toggleLocalDarkMode = () => {
     darkModeState.isDarkMode = !darkModeState.isDarkMode;
+    localDarkMode.value = darkModeState.isDarkMode ? 'dark' : 'light';
   };
 
   return { localDarkMode, toggleLocalDarkMode, globalDarkModeState };

--- a/example/useDarkMode.ts
+++ b/example/useDarkMode.ts
@@ -2,12 +2,14 @@ import { inject, ref, watch } from 'vue';
 
 export function useDarkMode() {
   const darkModeState = inject('darkModeState');
+  const globalDarkModeState = ref(darkModeState.isDarkMode);
   const localDarkMode = ref(darkModeState.isDarkMode);
 
   watch(
     () => darkModeState.isDarkMode,
     newVal => {
       localDarkMode.value = newVal;
+      globalDarkModeState.value = newVal;
     },
   );
 
@@ -15,5 +17,5 @@ export function useDarkMode() {
     darkModeState.isDarkMode = !darkModeState.isDarkMode;
   };
 
-  return { localDarkMode, toggleLocalDarkMode };
+  return { localDarkMode, toggleLocalDarkMode, globalDarkModeState };
 }

--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -70,9 +70,9 @@ export default defineComponent({
     onSelectedChange: {
       type: Function as PropType<(newVal: string | string[], oldVal: string | string[]) => void>,
     },
-    darkHighlightMode: {
-      type: Boolean,
-      default: false,
+    theme: {
+      type: String as PropType<'light' | 'dark'>,
+      default: 'light',
     },
   },
 
@@ -285,7 +285,7 @@ export default defineComponent({
             key={item.id}
             node={item}
             collapsed={!!state.hiddenPaths[item.path]}
-            darkHighlightMode={props.darkHighlightMode}
+            theme={props.theme}
             showDoubleQuotes={props.showDoubleQuotes}
             showLength={props.showLength}
             checked={selectedPaths.value.includes(item.path)}
@@ -321,7 +321,7 @@ export default defineComponent({
           class={{
             'vjs-tree': true,
             'is-virtual': props.virtual,
-            'dark-highlight-mode': props.darkHighlightMode,
+            dark: props.theme === 'dark',
           }}
           onScroll={props.virtual ? handleTreeScroll : undefined}
           style={

--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -70,6 +70,10 @@ export default defineComponent({
     onSelectedChange: {
       type: Function as PropType<(newVal: string | string[], oldVal: string | string[]) => void>,
     },
+    darkMode: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   slots: ['renderNodeKey', 'renderNodeValue'],
@@ -281,6 +285,7 @@ export default defineComponent({
             key={item.id}
             node={item}
             collapsed={!!state.hiddenPaths[item.path]}
+            darkMode={props.darkMode}
             showDoubleQuotes={props.showDoubleQuotes}
             showLength={props.showLength}
             checked={selectedPaths.value.includes(item.path)}
@@ -316,6 +321,7 @@ export default defineComponent({
           class={{
             'vjs-tree': true,
             'is-virtual': props.virtual,
+            'dark-mode': props.darkMode,
           }}
           onScroll={props.virtual ? handleTreeScroll : undefined}
           style={

--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -70,7 +70,7 @@ export default defineComponent({
     onSelectedChange: {
       type: Function as PropType<(newVal: string | string[], oldVal: string | string[]) => void>,
     },
-    darkMode: {
+    darkHighlightMode: {
       type: Boolean,
       default: false,
     },
@@ -285,7 +285,7 @@ export default defineComponent({
             key={item.id}
             node={item}
             collapsed={!!state.hiddenPaths[item.path]}
-            darkMode={props.darkMode}
+            darkHighlightMode={props.darkHighlightMode}
             showDoubleQuotes={props.showDoubleQuotes}
             showLength={props.showLength}
             checked={selectedPaths.value.includes(item.path)}
@@ -321,7 +321,7 @@ export default defineComponent({
           class={{
             'vjs-tree': true,
             'is-virtual': props.virtual,
-            'dark-mode': props.darkMode,
+            'dark-highlight-mode': props.darkHighlightMode,
           }}
           onScroll={props.virtual ? handleTreeScroll : undefined}
           style={

--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -64,6 +64,10 @@ export const treeNodePropsPass = {
     type: Boolean,
     default: false,
   },
+  darkMode: {
+    type: Boolean,
+    default: false,
+  },
   showKeyValueSpace: {
     type: Boolean,
     default: true,
@@ -213,6 +217,7 @@ export default defineComponent({
             'has-selector': props.showSelectController,
             'has-carets': props.showIcon,
             'is-highlight': props.highlightSelectedNode && props.checked,
+            'dark-mode': props.darkMode,
           }}
           onClick={handleNodeClick}
           style={props.style}

--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -64,9 +64,9 @@ export const treeNodePropsPass = {
     type: Boolean,
     default: false,
   },
-  darkHighlightMode: {
-    type: Boolean,
-    default: false,
+  theme: {
+    type: String as PropType<'light' | 'dark'>,
+    default: 'light',
   },
   showKeyValueSpace: {
     type: Boolean,
@@ -217,7 +217,7 @@ export default defineComponent({
             'has-selector': props.showSelectController,
             'has-carets': props.showIcon,
             'is-highlight': props.highlightSelectedNode && props.checked,
-            'dark-highlight-mode': props.darkHighlightMode,
+            dark: props.theme === 'dark',
           }}
           onClick={handleNodeClick}
           style={props.style}

--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -64,7 +64,7 @@ export const treeNodePropsPass = {
     type: Boolean,
     default: false,
   },
-  darkMode: {
+  darkHighlightMode: {
     type: Boolean,
     default: false,
   },
@@ -217,7 +217,7 @@ export default defineComponent({
             'has-selector': props.showSelectController,
             'has-carets': props.showIcon,
             'is-highlight': props.highlightSelectedNode && props.checked,
-            'dark-mode': props.darkMode,
+            'dark-highlight-mode': props.darkHighlightMode,
           }}
           onClick={handleNodeClick}
           style={props.style}

--- a/src/components/TreeNode/styles.less
+++ b/src/components/TreeNode/styles.less
@@ -35,6 +35,13 @@
       border-left: 1px dashed @border-color;
     }
   }
+
+  &.dark-mode {
+    &.is-highlight,
+    &:hover {
+      background-color: @highlight-bg-color-dark;
+    }
+  }
 }
 
 .@{css-prefix}-node-index {

--- a/src/components/TreeNode/styles.less
+++ b/src/components/TreeNode/styles.less
@@ -36,7 +36,7 @@
     }
   }
 
-  &.dark-mode {
+  &.dark-highlight-mode {
     &.is-highlight,
     &:hover {
       background-color: @highlight-bg-color-dark;

--- a/src/components/TreeNode/styles.less
+++ b/src/components/TreeNode/styles.less
@@ -36,7 +36,7 @@
     }
   }
 
-  &.dark-highlight-mode {
+  &.dark {
     &.is-highlight,
     &:hover {
       background-color: @highlight-bg-color-dark;

--- a/src/themes.less
+++ b/src/themes.less
@@ -6,7 +6,7 @@
 @color-info: #1d8ce0;
 @color-error: #ff4949;
 @color-success: #13ce66;
-@color-nil: #D55FDE;
+@color-nil: #d55fde;
 
 /* field values color */
 @color-string: @color-success;
@@ -17,6 +17,7 @@
 
 /* highlight */
 @highlight-bg-color: #e6f7ff;
+@highlight-bg-color-dark: #2e4558;
 
 /* comment */
 @comment-color: #bfcbd9;


### PR DESCRIPTION
This pull request introduces the integration of Dark Mode support for the Vue-Pretty-JSON website. Additionally, it incorporates a new property, darkHighlightMode.

### Rationale for the Change:

The primary motivation for this enhancement is to address the aesthetic challenges encountered when using Vue-Pretty-JSON on a dark background. Previously, the hover effect still showed a bright blue which made the text unreadable.

![grafik](https://github.com/leezng/vue-json-pretty/assets/23116945/26388a5c-174c-40b3-9c83-209363c6a8cd)


To resolve this issue, the pull request implements the darkHighlightMode, which now displays a dark blue on dark backgrounds, as demonstrated in the following image:

![grafik](https://github.com/leezng/vue-json-pretty/assets/23116945/65bfbe5c-ba6b-403c-9669-cc05ada3b664)

Since no other components seem to require an adjustment to work with darkmode, i've limited it to only the hover effect.