### PR TITLE
Add Path to emit

### DIFF
--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -233,12 +233,12 @@ export default defineComponent({
       if (props.collapsedOnClickBrackets) {
         updateCollapsedPaths(collapsed, path);
       }
-      emit('bracketsClick', collapsed);
+      emit('bracketsClick', collapsed, path);
     };
 
     const handleIconClick = (collapsed: boolean, path: string) => {
       updateCollapsedPaths(collapsed, path);
-      emit('iconClick', collapsed);
+      emit('iconClick', collapsed, path);
     };
 
     const handleValueChange = (value: unknown, path: string) => {


### PR DESCRIPTION
Receiving true or false doesn't provide much context to which bracket got collapsed in order to build smarter functionality and optimizations based on the collapsed field.