### PR TITLE
增加replacer属性方便自定义序列化json对象

### DIFF
--- a/example/Basic.vue
+++ b/example/Basic.vue
@@ -102,6 +102,7 @@
             ? state.useRenderNodeActionsSlot
             : undefined
         "
+        :replacer="replacer"
         style="position: relative"
       >
         <template v-if="state.useRenderNodeKeySlot" #renderNodeKey="{ node, defaultKey }">
@@ -133,7 +134,7 @@
 <script>
 import { defineComponent, reactive, watch } from 'vue';
 import { useDarkMode } from './useDarkMode';
-import VueJsonPretty from 'src';
+import VueJsonPretty, { defaultReplacer } from 'src';
 
 const defaultData = {
   status: 200,
@@ -204,12 +205,22 @@ export default defineComponent({
       },
     );
 
+    function replacer(key, value) {
+      if(value && typeof value === 'object') {
+        if(value.news_id === 51184) {
+          return ['number', 51184]
+        }
+      }
+      return defaultReplacer(key, value);
+    }
+
     return {
       state,
       pathCollapsible,
       localDarkMode,
       toggleLocalDarkMode,
       globalDarkModeState,
+      replacer,
     };
   },
 });

--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -198,6 +198,7 @@ export default defineComponent({
             ...startHiddenItem,
             showComma: item.showComma,
             content: isObject ? '{...}' : '[...]',
+            contentDataType: 'string',
             type: isObject ? 'objectCollapsed' : 'arrayCollapsed',
           } as NodeDataType;
           startHiddenItem = null;

--- a/src/components/Tree/index.tsx
+++ b/src/components/Tree/index.tsx
@@ -70,6 +70,9 @@ export default defineComponent({
       type: String as PropType<'light' | 'dark'>,
       default: 'light',
     },
+    replacer: {
+      type: Function as PropType<(key?: string | symbol, value?: unknown) => [string, unknown]>,
+    },
   },
 
   slots: ['renderNodeKey', 'renderNodeValue', 'renderNodeActions'],
@@ -87,7 +90,7 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const treeRef = ref<HTMLElement>();
 
-    const originFlatData = computed(() => jsonFlatten(props.data, props.rootPath));
+    const originFlatData = computed(() => jsonFlatten(props.data, props.rootPath, 0, void 0, props.replacer));
 
     const initHiddenPaths = (deep: number, collapsedNodeLength: number) => {
       return originFlatData.value.reduce((acc, item) => {

--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -149,7 +149,7 @@ export default defineComponent({
   ],
 
   setup(props, { emit }) {
-    const dataType = computed<string>(() => getDataType(props.node.content));
+    const dataType = computed<string>(() => props.node.contentDataType);
 
     const valueClass = computed(() => `vjs-value vjs-value-${dataType.value}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import { Plugin } from 'vue';
 import Tree from './components/Tree';
 
+export { getDataType, defaultReplacer } from './utils/index'
+
 export default Tree as typeof Tree & Plugin;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,6 +17,7 @@ export type JSONDataType = string | number | boolean | unknown[] | Record<string
 
 export interface JSONFlattenReturnType extends JSONFlattenOptions {
   content: string | number | null | boolean;
+  contentDataType: string;
   level: number;
   path: string;
 }
@@ -111,6 +112,7 @@ export function jsonFlatten(
   return [
     {
       content: data as JSONFlattenReturnType['content'],
+      contentDataType: dataType,
       level,
       key,
       index,


### PR DESCRIPTION
类似于[`JSON.stringify(value, replacer)`](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)，期望可以提供一个replacer函数来自定义序列化某些数据。