### PR TITLE
fix: add exports map so Node resolves the ESM build

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -41,6 +41,8 @@ if (!isExampleEnv) {
     webpackConfig.entry = {
       'vue-json-pretty': './src/index.ts',
     };
+    // .mjs so Node parses the bundle as ESM (the package has no "type": "module")
+    webpackConfig.output.filename = `${distPath}/[name].mjs`;
     webpackConfig.experiments = {
       outputModule: true,
     };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,19 @@
   "version": "2.2.3",
   "description": "A JSON tree view component that is easy to use and also supports data selection.",
   "author": "leezng <im.leezng@gmail.com>",
+  "type": "commonjs",
   "main": "lib/vue-json-pretty.js",
-  "module": "esm/vue-json-pretty.js",
+  "module": "esm/vue-json-pretty.mjs",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./esm/vue-json-pretty.mjs",
+      "require": "./lib/vue-json-pretty.js"
+    },
+    "./lib/styles.css": "./lib/styles.css",
+    "./esm/styles.css": "./esm/styles.css",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "dev": "node build/dev-server.js",
     "build": "npm run build:main && npm run build:esm && npm run build:dts",


### PR DESCRIPTION
Fixes #312

## Problem

When Vite externalizes `vue-json-pretty` during SSR (the default in VitePress and other Vite SSR setups), Node resolves the package itself. Without an `exports` field it falls back to `main`, the minified UMD bundle, whose wrapper defeats Node's named-export detection — so `import VueJsonPretty from 'vue-json-pretty'` yields the module wrapper instead of the component, and SSR renders `<!---->` with a hydration mismatch on the client.

## Fix

**`package.json`** — add an `exports` map and declare the package format:

```json
"type": "commonjs",
"module": "esm/vue-json-pretty.mjs",
"exports": {
  ".": {
    "types": "./types/index.d.ts",
    "import": "./esm/vue-json-pretty.mjs",
    "require": "./lib/vue-json-pretty.js"
  },
  "./lib/styles.css": "./lib/styles.css",
  "./esm/styles.css": "./esm/styles.css",
  "./package.json": "./package.json"
}
```

**`build/webpack.prod.conf.js`** — emit the ESM build as `esm/vue-json-pretty.mjs` instead of `.js`.

## Why this shape

- The ESM bundle uses ESM syntax, but Node decides `.js` format from the nearest `package.json` `"type"` — in a CJS package it would parse the file as CommonJS and the `import` condition would throw. `.mjs` is [unambiguously ESM to Node](https://nodejs.org/api/packages.html#determining-module-system) and is what [vue](https://unpkg.com/vue/package.json), [element-plus](https://unpkg.com/element-plus/package.json) and [naive-ui](https://unpkg.com/naive-ui/package.json) ship. The alternative — a nested `esm/package.json` with `{"type": "module"}` — works too, but has tooling edge cases (e.g. jestjs/jest#10647) and no mainstream Vue library uses it.
- Explicit `"type": "commonjs"` follows the [Node docs](https://nodejs.org/api/packages.html#type) ("package authors should always include the type field") and publint's [`USE_TYPE`](https://publint.dev/rules#use_type) rule.
- `exports` blocks undeclared subpaths, so the documented `vue-json-pretty/lib/styles.css` import (and its `esm/` twin) are declared explicitly — same pattern as element-plus.
- The only breaking surface is deep-importing `esm/vue-json-pretty.js` by exact filename, which was never documented; the `module` field now points at the `.mjs`.

## Verification

Built locally and rendered with `@vue/server-renderer` in plain Node ESM (the externalized-SSR case from the issue):

| Case | Before | After |
| --- | --- | --- |
| `import` + `renderToString` | `<!---->` + missing-render warning | full `.vjs-tree` markup |
| `require('vue-json-pretty')` | works | works |
| `lib/styles.css` / `esm/styles.css` deep imports | work | work |

`publint` reports no errors. Its one remaining warning — the shared `types` file resolves as CJS under the `import` condition ([FalseCJS](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md)) — predates this PR and needs TypeScript ≥ 4.7 to emit a `.d.mts`, so it's left out of scope.
